### PR TITLE
undefined.png fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -158,6 +158,9 @@ var trainerFunc = function(data, user_index) {
               icon: 'image/forts/img_pokestop.png'
             });
           } else {
+            if (teams[fort.owned_by_team] == undefined) {
+              continue; 
+            }
             forts[fort.id] = new google.maps.Marker({
               map: map,
               position: {


### PR DESCRIPTION
image/forts/undefined.png:
This is being loaded sometimes when location JSON is received.
Sometimes, the location gives us JSONs such as:
{last_modified_timestamp_ms: 1469448804831, latitude: 40.772032, enabled: true, id: "e678ed4ce93646b88d162ed02f229999.16", longitude: -73.947655}
Here,  this location is not a gym, and not a pokestop. Why? Pokestops need to have type:1.
This example cannot be a gym because owned_by_team is not specified. 
Because our code checks if .type is 1 (then pokestop) else it is "definitely" a gym, it was considered a gym.
So I've added a check such that the JSON needs to have a owned_by_team to pass and add the google marker.
