### PR TITLE
[Fix] Candy displayed in Pokedex view

### DIFF
--- a/main.js
+++ b/main.js
@@ -672,7 +672,7 @@ function sortAndShowPokedex(sortOn, user_id) {
             '<br>Times Caught: ' +
             pkmnCap +
             '<br>Candy: ' +
-            pkmnCap +
+            candyNum +
             '</div>';
   }
   out += '</div>';


### PR DESCRIPTION
Display correct amount of candy in pokedex view.

Previously shows No. of Pokemon Captured instead.
