### PR TITLE
Add secondary sort by CP for sort by name and id

### DIFF
--- a/main.js
+++ b/main.js
@@ -501,12 +501,18 @@ var mapView = {
         sortedPokemon.sort(function(a, b) {
           if (a.name < b.name) return -1;
           if (a.name > b.name) return 1;
+          if (a.cp > b.cp) return -1;
+          if (a.cp < b.cp) return 1;
           return 0;
         });
         break;
       case 'id':
         sortedPokemon.sort(function(a, b) {
-          return a.id - b.id;
+          if (a.id < b.id) return -1;
+          if (a.id > b.id) return 1;
+          if (a.cp > b.cp) return -1;
+          if (a.cp < b.cp) return 1;
+          return 0;
         });
         break;
       case 'cp':


### PR DESCRIPTION
Add secondary sort by CP when sorted by name and id as seen in the game, so its easier to find highest CP pokemon for each specific name / id
