### PR TITLE
No cached loadJSON

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -896,7 +896,7 @@ var mapView = {
         }
       }
     };
-    xhr.open('GET', path, true);
+    xhr.open('GET', path + "?v=" + Date.now(), true);
     xhr.send();
   },
 


### PR DESCRIPTION
Same thing https://github.com/OpenPoGo/OpenPoGoWeb/pull/114 aimed for.
Everything sent to loadJSON will now be loaded with 0% chance for cached results.
https://github.com/OpenPoGo/OpenPoGoWeb/pull/114 close this too.
